### PR TITLE
doc updates: better support for dot-separated keys

### DIFF
--- a/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
@@ -108,12 +108,14 @@ impl<'s> Storage<'s> for ElasticsearchStorage {
         impl Into<serde_json::Value> for EsOperation {
             fn into(self) -> serde_json::Value {
                 match self.0 {
-                    UpdateOperation::Set { ident, value } => json!({
-                        "script": {
-                            "source": format!("ctx._source.{} = params.value", ident),
-                            "params": { "value": value }
-                        }
-                    }),
+                    UpdateOperation::Set { ident, value } => {
+                        let updated_part = ident
+                            .split('.')
+                            .rev()
+                            .fold(value.into(), |val, key| json!({ key: val }));
+
+                        json!({ "doc": updated_part })
+                    }
                 }
             }
         }

--- a/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
@@ -109,6 +109,10 @@ impl<'s> Storage<'s> for ElasticsearchStorage {
             fn into(self) -> serde_json::Value {
                 match self.0 {
                     UpdateOperation::Set { ident, value } => {
+                        // Generate the part of the document that must be updated. For example with
+                        // `ident` = "properties.image" and `value` = "https://foo.jpg", this will
+                        // generate the following JSON:
+                        // { "properties": { "image": "https://foo.jpg" } }
                         let updated_part = ident
                             .split('.')
                             .rev()

--- a/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
@@ -17,7 +17,7 @@ use crate::domain::{
         configuration::{root_doctype_dataset_ts, ContainerConfig, ContainerVisibility},
         index::Index,
         stats::InsertStats,
-        update::UpdateOperation,
+        update::{generate_document_parts, UpdateOperation},
     },
     ports::secondary::storage::{Error as StorageError, Storage},
 };
@@ -107,48 +107,8 @@ impl<'s> Storage<'s> for ElasticsearchStorage {
         #[allow(clippy::from_over_into)]
         impl Into<serde_json::Value> for EsOperation {
             fn into(self) -> serde_json::Value {
-                // match self.0 {
-                //     UpdateOperation::Set { ident, value } => {
-                // Generate the part of the document that must be updated. For example with
-                // `ident` = "properties.image" and `value` = "https://foo.jpg", this will
-                // generate the following JSON:
-                // { "properties": { "image": "https://foo.jpg" } }
-                //         let updated_part = ident
-                //             .split('.')
-                //             .rev()
-                //             .fold(value.into(), |val, key| json!({ key: val }));
-                //
-                //         json!({ "doc": updated_part })
-                //     }
-                // }
-
-                self.0.into_iter().fold(json!({}), |mut result, op| {
-                    match op {
-                        // Adds the part of the document that must be updated to `result`. For
-                        // example if at current iteration `result` has this value:
-                        //   { "properties": { "review": "excellent" } }
-                        // And `ident` = "properties.image", `value` = "https://foo.jpg", then this
-                        // will update `result` with this value:
-                        //   { "properties": { "review", "excellent", "image": "https://foo.jpg" } }
-                        UpdateOperation::Set { ident, value } => {
-                            // Get a reference to the position in the JSON where the value must be
-                            // inserted.
-                            let target = ident.split('.').fold(&mut result, |curr, key| {
-                                if curr.get(key).is_none() {
-                                    curr[key] = json!({});
-                                }
-
-                                &mut curr[key]
-                            });
-
-                            // Update target object with the value, in most cases this is just an
-                            // empty object that was just created to construct the full path.
-                            *target = value.into();
-                        }
-                    }
-
-                    result
-                })
+                let updated_parts = generate_document_parts(self.0);
+                json!({ "doc": updated_parts })
             }
         }
 

--- a/libs/mimir/src/domain/model/update.rs
+++ b/libs/mimir/src/domain/model/update.rs
@@ -16,7 +16,7 @@ pub fn generate_document_parts(ops: Vec<UpdateOperation>) -> serde_json::Value {
             //   { "properties": { "review": "excellent" } }
             // And `ident` = "properties.image", `value` = "https://foo.jpg", then this
             // will update `result` with this value:
-            //   { "properties": { "review", "excellent", "image": "https://foo.jpg" } }
+            //   { "properties": { "review": "excellent", "image": "https://foo.jpg" } }
             UpdateOperation::Set { ident, value } => {
                 // Get a reference to the position in the JSON where the value must be
                 // inserted.

--- a/libs/mimir/src/domain/model/update.rs
+++ b/libs/mimir/src/domain/model/update.rs
@@ -1,5 +1,81 @@
+use serde_json::json;
+
 #[derive(Clone, Debug)]
 pub enum UpdateOperation {
     /// Update a field `ident` with given value
     Set { ident: String, value: String },
+}
+
+/// Given the list of operations to perform, generate the parts of the documents that must be
+/// updated.
+pub fn generate_document_parts(ops: Vec<UpdateOperation>) -> serde_json::Value {
+    ops.into_iter().fold(json!({}), |mut result, op| {
+        match op {
+            // Adds the part of the document that must be updated to `result`. For
+            // example if at current iteration `result` has this value:
+            //   { "properties": { "review": "excellent" } }
+            // And `ident` = "properties.image", `value` = "https://foo.jpg", then this
+            // will update `result` with this value:
+            //   { "properties": { "review", "excellent", "image": "https://foo.jpg" } }
+            UpdateOperation::Set { ident, value } => {
+                // Get a reference to the position in the JSON where the value must be
+                // inserted.
+                let target = ident.split('.').fold(&mut result, |curr, key| {
+                    if curr.get(key).is_none() {
+                        curr[key] = json!({});
+                    }
+
+                    &mut curr[key]
+                });
+
+                // Update target object with the value, in most cases this is just an
+                // empty object that was just created to construct the full path.
+                *target = value.into();
+            }
+        }
+
+        result
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_with_empty_updates() {
+        let doc = generate_document_parts(vec![]);
+        assert_eq!(doc, json!({}));
+    }
+
+    #[test]
+    fn generate_with_merged_updates() {
+        let ops = vec![
+            UpdateOperation::Set {
+                ident: "address.city.postcode".into(),
+                value: "95600".into(),
+            },
+            UpdateOperation::Set {
+                ident: "address.city.name".into(),
+                value: "Eaubonne".into(),
+            },
+            UpdateOperation::Set {
+                ident: "name".into(),
+                value: "townhall".into(),
+            },
+        ];
+
+        assert_eq!(
+            generate_document_parts(ops),
+            json!({
+                "name": "townhall",
+                "address": {
+                    "city": {
+                        "name": "Eaubonne",
+                        "postcode": "95600"
+                    }
+                }
+            })
+        )
+    }
 }

--- a/libs/mimir/src/domain/ports/primary/generate_index.rs
+++ b/libs/mimir/src/domain/ports/primary/generate_index.rs
@@ -123,7 +123,7 @@ where
     #[tracing::instrument(skip(self, updates))]
     pub async fn update_documents(
         self,
-        updates: impl Stream<Item = (String, UpdateOperation)> + Send + Sync + 's,
+        updates: impl Stream<Item = (String, Vec<UpdateOperation>)> + Send + Sync + 's,
     ) -> Result<ContainerGenerator<'a, D, T>, ModelError> {
         let stats = self
             .storage

--- a/libs/mimir/src/domain/ports/secondary/storage.rs
+++ b/libs/mimir/src/domain/ports/secondary/storage.rs
@@ -63,7 +63,7 @@ pub trait Storage<'s> {
 
     async fn update_documents<S>(&self, index: String, operations: S) -> Result<InsertStats, Error>
     where
-        S: Stream<Item = (String, UpdateOperation)> + Send + Sync + 's;
+        S: Stream<Item = (String, Vec<UpdateOperation>)> + Send + Sync + 's;
 
     async fn publish_index(
         &self,
@@ -105,7 +105,7 @@ where
 
     async fn update_documents<S>(&self, index: String, operations: S) -> Result<InsertStats, Error>
     where
-        S: Stream<Item = (String, UpdateOperation)> + Send + Sync + 's,
+        S: Stream<Item = (String, Vec<UpdateOperation>)> + Send + Sync + 's,
     {
         (**self).update_documents(index, operations).await
     }

--- a/libs/mimir/src/tests/generate_and_update.rs
+++ b/libs/mimir/src/tests/generate_and_update.rs
@@ -44,8 +44,6 @@ async fn generate_and_update_poi(id: &str, updates: Vec<UpdateOperation>) -> Vec
         number_of_replicas: 0,
     };
 
-    let poi_updates = updates.into_iter().map(|op| (id.to_string(), op));
-
     client
         .init_container(&container_config)
         .await
@@ -53,7 +51,7 @@ async fn generate_and_update_poi(id: &str, updates: Vec<UpdateOperation>) -> Vec
         .insert_documents(stream::iter([sample_poi()]))
         .await
         .unwrap()
-        .update_documents(stream::iter(poi_updates))
+        .update_documents(stream::iter([(id.to_string(), updates)]))
         .await
         .unwrap()
         .publish()


### PR DESCRIPTION
For some reason when using a dot-sparated key chain to update a document
value, elasticsearch will attempt to update the mapping. Which conflicts
with `properties` which is flattened.

For example the following update operation fails:

```json
{
   "script": {
       "source": "ctx._source['properties.image'] = \"test\""
    }
}
```

> Could not dynamically add mapping for field [properties.image]. Existing mapping for [properties] must be of type object but found [flattened].

And the following one succeeds

```json
{
   "script": {
       "source": "ctx._source['properties']['image'] = \"test\""
    }
}
```

So the approach of this PR is to manually split key and subkeys and
generate the subtree for ES to update:

```json
{
    "doc": {
        "properties": {
            "image": "test"
        }
    }
}
```

EDIT: And it also gets rid of the use of `script` which could be problematic when there are hardcoded values inside (formerly the key)