### PR TITLE
feat: add 'curl in bragi's docker image

### DIFF
--- a/docker/bragi/Dockerfile
+++ b/docker/bragi/Dockerfile
@@ -59,12 +59,12 @@ ARG DEBIAN_VERSION
 
 RUN if [ "${DEBIAN_VERSION}" = "buster" ]; then \
   apt-get update \
-    && apt-get install -y libcurl4 sqlite3 \
+    && apt-get install -y curl libcurl4 sqlite3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
 elif [ "${DEBIAN_VERSION}" = "stretch" ]; then \
   apt-get update \
-    && apt-get install -y libcurl3 sqlite3 \
+    && apt-get install -y curl libcurl3 sqlite3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
 else \


### PR DESCRIPTION
In order to be able to do some `healthcheck` inside Docker, we need some way to query the `/status` API from inside the docker image. Note that this solution is not ideal since `curl` is not necessary for `bragi` and therefore, it adds a dependency inside that image (and therefore, possibly some attack surface). [But one of the alternative is not necessarily easier](https://blog.sixeyed.com/docker-healthchecks-why-not-to-use-curl-or-iwr/).

ref: NAV-1358