### PR TITLE
ci: ignore sonarcloud analysis for 'dependabot'

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   clippy:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     name: Analyzing code with Clippy
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We don't need a Sonarcloud analysis on `dependabot` PR since they do not change anything about tests and code (so no coverage change).