### PR TITLE
Update docker CI to be compatible with forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  DOCKER_ORG: navitia
 
 jobs:
   build:
@@ -41,7 +40,6 @@ jobs:
           echo "${{ steps.rust_version.outputs.rustupToolchain }}"
 
       - name: Login to DockerHub
-        if: github.event_name == 'push'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USER }}
@@ -51,13 +49,13 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/*/}
           if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-            IMAGE_TAG=$GITHUB_SHA
+            IMAGE_TAG=$GITHUB_HEAD_REF
           elif [ "$VERSION" == "master" ]; then
             IMAGE_TAG=latest
           else
             IMAGE_TAG=$VERSION
           fi
-          echo "DOCKER_IMAGE=$DOCKER_ORG/${{ matrix['image'] }}:$IMAGE_TAG" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${{ secrets.DOCKER_ORG }}/${{ matrix['image'] }}:$IMAGE_TAG" >> $GITHUB_ENV
 
       - name: Build docker image
         run: >-
@@ -68,5 +66,4 @@ jobs:
           --tag $DOCKER_IMAGE
           .
 
-      - if: github.event_name == 'push'
-        run: docker push $DOCKER_IMAGE
+      - run: docker push $DOCKER_IMAGE

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -31,6 +31,7 @@ jobs:
         if: "${{ env.SONAR_TOKEN != '' }}"
         run: cargo-sonar --features clippy --clippy-path clippy.json
       - name: Run sonar-scanner
+        uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,14 +26,15 @@ jobs:
       - name: Install 'cargo-sonar'
         run: cargo install cargo-sonar --version 0.9.0 --locked
       - name: Convert into Sonar compatible format
-        if: ${{ env.DOCKER_ORG == 'navitia' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: "${{ env.SONAR_TOKEN != '' }}"
         run: cargo-sonar --features clippy --clippy-path clippy.json
       - name: Run sonar-scanner
-        if: ${{ env.DOCKER_ORG == 'navitia' }}
-        uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: "${{ env.SONAR_TOKEN != '' }}"
         with:
           args: >
             -Dsonar.projectKey=Hove_mimirsbrunn

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can also fetch official images from DockerHub here:
 If you want to get the commit ref used to build the latest image you can run the following command:
 
 ```bash
-docker inspect --format='{{index .Config.Labels "org.label-schema.vcs-ref"}}' qwantresearch/mimirsbrunn:latest
+docker inspect --format='{{index .Config.Labels "org.label-schema.vcs-ref"}}' navitia/mimirsbrunn:latest
 ```
 
 ### Manually

--- a/README.md
+++ b/README.md
@@ -68,10 +68,28 @@ For running end to end or unit tests, you need the docker engine available.
 
 ## Installing
 
+### Debian
+
 You can install Mimirsbrunn from debian packages available as build artifacts on the repository
 homepage. [FIXME Where are .deb ?]
 
-You can also build Mimirsbrunn manually, as the following instructions explain.
+### Docker
+
+You can also fetch official images from DockerHub here:
+
+ - [navitia/mimirsbrunn:latest](https://hub.docker.com/r/navitia/mimirsbrunn)
+ - [navitia/bragi:latest](https://hub.docker.com/r/navitia/bragi)
+
+
+If you want to get the commit ref used to build the latest image you can run the following command:
+
+```bash
+docker inspect --format='{{index .Config.Labels "org.label-schema.vcs-ref"}}' qwantresearch/mimirsbrunn:latest
+```
+
+### Manually
+
+You can build Mimirsbrunn manually, as the following instructions explain.
 
 You need to retrieve the project and build it using the rust compiler:
 

--- a/sonarcloud.yml
+++ b/sonarcloud.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   clippy:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     name: Analyzing code with Clippy
     runs-on: ubuntu-latest
     steps:
@@ -26,8 +26,10 @@ jobs:
       - name: Install 'cargo-sonar'
         run: cargo install cargo-sonar --version 0.9.0 --locked
       - name: Convert into Sonar compatible format
+        if: ${{ env.DOCKER_ORG == 'navitia' }}
         run: cargo-sonar --features clippy --clippy-path clippy.json
       - name: Run sonar-scanner
+        if: ${{ env.DOCKER_ORG == 'navitia' }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We are currently experimenting working on a fork of mimirsbrunn, which we would keep up to date with mimirsbrunn but in which we could operate more freely (eg. merging before you had time to review in order to deploy).

This PR proposes a change to make the CI work on several repos:
 -  replacing the hardcoded "navitia" org with a secret value (ie. you would need to add DOCKER_ORG=navitia in the secrets before merging this PR)
 - push docker images for branches and use the branch name as label, just for convenience