### PR TITLE
[ntfs2mimir] attach admins from file

### DIFF
--- a/config/bano2mimir/default.toml
+++ b/config/bano2mimir/default.toml
@@ -1,14 +1,15 @@
 nb_threads = 2
 update_templates = true
 
-# If a cosmogony_file is configured, ntfs2mimir will read the admins from this file.
-# If such a file is not configured, ntfs2mimir will read the admins from elasticsearch
 
+
+# If the admins sections is present, the admins will be read in the cosmogony file.
+# Otherwise, admins will be fetched  from elasticsearch
+# [admins]
 # cosmogony_file = "/home/pascal/mimirsbrunn/cosmogony-europe.jsonl.gz"
-
 # configuration for reading the cosmogony file
-french_id_retrocompatibility = true
-langs = [ "fr" ]
+# french_id_retrocompatibility = true
+# langs = [ "fr" ]
 
 [container]
   name = "addr"

--- a/config/bano2mimir/default.toml
+++ b/config/bano2mimir/default.toml
@@ -1,6 +1,15 @@
 nb_threads = 2
 update_templates = true
 
+# If a cosmogony_file is configured, ntfs2mimir will read the admins from this file.
+# If such a file is not configured, ntfs2mimir will read the admins from elasticsearch
+
+# cosmogony_file = "/home/pascal/mimirsbrunn/cosmogony-europe.jsonl.gz"
+
+# configuration for reading the cosmogony file
+french_id_retrocompatibility = true
+langs = [ "fr" ]
+
 [container]
   name = "addr"
   dataset = "fr"

--- a/config/ntfs2mimir/default.toml
+++ b/config/ntfs2mimir/default.toml
@@ -13,7 +13,7 @@ langs = [ "fr" ]
 
 [container]
   name = "stop"
-  dataset = "third_local"
+  dataset = "fr"
   visibility = "public"
   number_of_shards = 1
   number_of_replicas = 0

--- a/config/ntfs2mimir/default.toml
+++ b/config/ntfs2mimir/default.toml
@@ -1,9 +1,19 @@
-nb_threads = 2
+nb_threads = 1
 update_templates = true
+
+
+# If a cosmogony_file is configured, ntfs2mimir will read the admins from this file.
+# If such a file is not configured, ntfs2mimir will read the admins from elasticsearch
+
+# cosmogony_file = "/home/pascal/mimirsbrunn/cosmogony-europe.jsonl.gz"
+
+# configuration for reading the cosmogony file
+french_id_retrocompatibility = true
+langs = [ "fr" ]
 
 [container]
   name = "stop"
-  dataset = "fr"
+  dataset = "third_local"
   visibility = "public"
   number_of_shards = 1
   number_of_replicas = 0

--- a/config/ntfs2mimir/default.toml
+++ b/config/ntfs2mimir/default.toml
@@ -2,14 +2,13 @@ nb_threads = 1
 update_templates = true
 
 
-# If a cosmogony_file is configured, ntfs2mimir will read the admins from this file.
-# If such a file is not configured, ntfs2mimir will read the admins from elasticsearch
-
+# If the admins sections is present, the admins will be read in the cosmogony file.
+# Otherwise, admins will be fetched  from elasticsearch
+# [admins]
 # cosmogony_file = "/home/pascal/mimirsbrunn/cosmogony-europe.jsonl.gz"
-
 # configuration for reading the cosmogony file
-french_id_retrocompatibility = true
-langs = [ "fr" ]
+# french_id_retrocompatibility = true
+# langs = [ "fr" ]
 
 [container]
   name = "stop"

--- a/config/openaddresses2mimir/default.toml
+++ b/config/openaddresses2mimir/default.toml
@@ -1,14 +1,13 @@
 nb_threads = 2
 update_templates = true
 
-# If a cosmogony_file is configured, openaddresses2mimir will read the admins from this file.
-# If such a file is not configured, openaddresses2mimir will read the admins from elasticsearch
-
+# If the admins sections is present, the admins will be read in the cosmogony file.
+# Otherwise, admins will be fetched  from elasticsearch
+# [admins]
 # cosmogony_file = "/home/pascal/mimirsbrunn/cosmogony-europe.jsonl.gz"
-
 # configuration for reading the cosmogony file
-french_id_retrocompatibility = true
-langs = [ "fr" ]
+# french_id_retrocompatibility = true
+# langs = [ "fr" ]
 
 [container]
   name = "addr"

--- a/config/openaddresses2mimir/default.toml
+++ b/config/openaddresses2mimir/default.toml
@@ -1,6 +1,15 @@
 nb_threads = 2
 update_templates = true
 
+# If a cosmogony_file is configured, openaddresses2mimir will read the admins from this file.
+# If such a file is not configured, openaddresses2mimir will read the admins from elasticsearch
+
+# cosmogony_file = "/home/pascal/mimirsbrunn/cosmogony-europe.jsonl.gz"
+
+# configuration for reading the cosmogony file
+french_id_retrocompatibility = true
+langs = [ "fr" ]
+
 [container]
   name = "addr"
   dataset = "fr"

--- a/config/osm2mimir/default.toml
+++ b/config/osm2mimir/default.toml
@@ -1,6 +1,15 @@
 nb_threads = 2
 update_templates = true
 
+# If a cosmogony_file is configured, osm2mimir will read the admins from this file.
+# If such a file is not configured, osm2mimir will read the admins from elasticsearch
+
+# cosmogony_file = "/home/pascal/mimirsbrunn/cosmogony-europe.jsonl.gz"
+
+# configuration for reading the cosmogony file
+french_id_retrocompatibility = true
+langs = [ "fr" ]
+
 [container-poi]
   name = "poi"
   dataset = "fr"

--- a/config/osm2mimir/default.toml
+++ b/config/osm2mimir/default.toml
@@ -1,14 +1,13 @@
 nb_threads = 2
 update_templates = true
 
-# If a cosmogony_file is configured, osm2mimir will read the admins from this file.
-# If such a file is not configured, osm2mimir will read the admins from elasticsearch
-
+# If the admins sections is present, the admins will be read in the cosmogony file.
+# Otherwise, admins will be fetched  from elasticsearch
+# [admins]
 # cosmogony_file = "/home/pascal/mimirsbrunn/cosmogony-europe.jsonl.gz"
-
 # configuration for reading the cosmogony file
-french_id_retrocompatibility = true
-langs = [ "fr" ]
+# french_id_retrocompatibility = true
+# langs = [ "fr" ]
 
 [container-poi]
   name = "poi"

--- a/config/poi2mimir/default.toml
+++ b/config/poi2mimir/default.toml
@@ -8,3 +8,10 @@ update_templates = true
 # configuration for reading the cosmogony file
 # french_id_retrocompatibility = true
 # langs = [ "fr" ]
+
+[container]
+  name = "poi"
+  dataset = "fr"
+  visibility = "public"
+  number_of_shards = 1
+  number_of_replicas = 0

--- a/config/poi2mimir/default.toml
+++ b/config/poi2mimir/default.toml
@@ -1,9 +1,10 @@
 nb_threads = 2
 update_templates = true
 
-[container]
-  name = "poi"
-  dataset = "fr"
-  visibility = "public"
-  number_of_shards = 1
-  number_of_replicas = 0
+# If the admins sections is present, the admins will be read in the cosmogony file.
+# Otherwise, admins will be fetched  from elasticsearch
+# [admins]
+# cosmogony_file = "/home/pascal/mimirsbrunn/cosmogony-europe.jsonl.gz"
+# configuration for reading the cosmogony file
+# french_id_retrocompatibility = true
+# langs = [ "fr" ]

--- a/libs/tests/src/ntfs.rs
+++ b/libs/tests/src/ntfs.rs
@@ -52,7 +52,7 @@ pub async fn index_stops(
         .iter()
         .collect();
 
-    let mut config: mimirsbrunn::settings::ntfs2mimir::Settings = common::config::config_from(
+    let mut settings: mimirsbrunn::settings::ntfs2mimir::Settings = common::config::config_from(
         &config_dir,
         &["ntfs2mimir", "elasticsearch"],
         "testing",
@@ -64,12 +64,11 @@ pub async fn index_stops(
     .expect("invalid ntfs2mimir configuration");
 
     // Use dataset set by test instead of default config
-    config.container.dataset = dataset.to_string();
+    settings.container.dataset = dataset.to_string();
 
     mimirsbrunn::stops::index_ntfs(
-        input_dir,
-        &config.container,
-        &config.physical_mode_weight,
+        &input_dir,
+        &settings,
         client,
     )
     .await

--- a/libs/tests/src/ntfs.rs
+++ b/libs/tests/src/ntfs.rs
@@ -66,13 +66,9 @@ pub async fn index_stops(
     // Use dataset set by test instead of default config
     settings.container.dataset = dataset.to_string();
 
-    mimirsbrunn::stops::index_ntfs(
-        &input_dir,
-        &settings,
-        client,
-    )
-    .await
-    .expect("error while indexing Ntfs");
+    mimirsbrunn::stops::index_ntfs(&input_dir, &settings, client)
+        .await
+        .expect("error while indexing Ntfs");
 
     Ok(Status::Done)
 }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -200,7 +200,6 @@ fn read_zones(path: &Path) -> Result<impl Iterator<Item = Zone> + Send + Sync, E
     Ok(iter)
 }
 
-
 pub async fn index_cosmogony(
     path: &Path,
     langs: Vec<String>,
@@ -212,14 +211,11 @@ pub async fn index_cosmogony(
     import_admins(client, config, futures::stream::iter(admins)).await
 }
 
-
-
-
 pub fn read_admin_in_cosmogony_file(
     path: &Path,
     langs: Vec<String>,
     french_id_retrocompatibility: bool,
-) -> Result<impl Iterator<Item=Admin>, Error> {
+) -> Result<impl Iterator<Item = Admin>, Error> {
     info!("building map cosmogony id => osm id");
     let mut cosmogony_id_to_osm_id = BTreeMap::new();
     let max_weight = places::admin::ADMIN_MAX_WEIGHT;
@@ -247,7 +243,7 @@ pub fn read_admin_in_cosmogony_file(
         })
         .collect::<HashMap<_, _>>();
 
-    let admins  = read_zones(path)?.map(move |z| {
+    let admins = read_zones(path)?.map(move |z| {
         z.into_admin(
             &cosmogony_id_to_osm_id,
             &langs,

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -247,7 +247,6 @@ pub fn read_admin_in_cosmogony_file(
         })
         .collect::<HashMap<_, _>>();
 
-    info!("importing admins into Elasticsearch");
     let admins  = read_zones(path)?.map(move |z| {
         z.into_admin(
             &cosmogony_id_to_osm_id,

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -118,7 +118,7 @@ impl AdminGeoFinder {
         client: &ElasticsearchStorage,
     ) -> Result<AdminGeoFinder, admin::Error> {
         let admins = fetch_admins(admin_settings, client).await?;
-        let geofinder = AdminGeoFinder::from_iter(admins.into_iter());
+        let geofinder: AdminGeoFinder = admins.into_iter().collect();
         Ok(geofinder)
     }
 

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -33,6 +33,7 @@ use geo::algorithm::{
     intersects::Intersects,
 };
 use geo_types::{MultiPolygon, Point};
+use mimir::adapters::secondary::elasticsearch::ElasticsearchStorage;
 use places::admin::Admin;
 use rstar::{Envelope, PointDistance, RTree, RTreeObject, SelectionFunction, AABB};
 use std::{
@@ -41,6 +42,8 @@ use std::{
     sync::Arc,
 };
 use tracing::{info, warn};
+
+use crate::{admin, admin::fetch_admins, settings::admin_settings::AdminSettings};
 
 // This is a structure which is used in the RTree to customize the list of objects returned
 // when searching at a given location. This version just focuses on the envelope of the object,
@@ -110,6 +113,15 @@ pub struct AdminGeoFinder {
 }
 
 impl AdminGeoFinder {
+    pub async fn build(
+        admin_settings: &AdminSettings,
+        client: &ElasticsearchStorage,
+    ) -> Result<AdminGeoFinder, admin::Error> {
+        let admins = fetch_admins(admin_settings, client).await?;
+        let geofinder = AdminGeoFinder::from_iter(admins.into_iter());
+        Ok(geofinder)
+    }
+
     pub fn insert(&mut self, admin: Admin) {
         let mut admin = admin;
         let boundary = std::mem::replace(&mut admin.boundary, None);

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -29,22 +29,16 @@
 // www.navitia.io
 
 use clap::Parser;
-use futures::stream::StreamExt;
 use mimir::domain::ports::primary::generate_index::GenerateIndex;
 use mimirsbrunn::{
-    addr_reader::import_addresses_from_input_path, admin::read_admin_in_cosmogony_file,
-    utils::template::update_templates,
+    addr_reader::import_addresses_from_input_path, admin::fetch_admins,
+    settings::admin_settings::AdminSettings, utils::template::update_templates,
 };
 use snafu::{ResultExt, Snafu};
 use std::sync::Arc;
-use tracing::warn;
 
-use mimir::{
-    adapters::secondary::elasticsearch,
-    domain::ports::{primary::list_documents::ListDocuments, secondary::remote::Remote},
-};
+use mimir::{adapters::secondary::elasticsearch, domain::ports::secondary::remote::Remote};
 use mimirsbrunn::{bano::Bano, settings::bano2mimir as settings};
-use places::admin::Admin;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -109,32 +103,8 @@ async fn run(
     // Lets say we're indexing a single bano department.... we don't need to retrieve
     // the admins for other regions!
     let into_addr = {
-        let admins: Vec<Admin> = if let Some(cosmogony_file_path) = &settings.cosmogony_file {
-            read_admin_in_cosmogony_file(
-                cosmogony_file_path,
-                settings.langs.clone(),
-                settings.french_id_retrocompatibility,
-            )
-            .map_err(|err| Error::AdminRetrieval {
-                details: err.to_string(),
-            })?
-            .collect()
-        } else {
-            match client.list_documents().await {
-                Ok(stream) => {
-                    stream
-                        .map(|admin| admin.expect("could not parse admin"))
-                        .collect()
-                        .await
-                }
-                Err(err) => {
-                    warn!("administratives regions not found in es db. {:?}", err);
-                    return Err(Box::new(Error::AdminRetrieval {
-                        details: err.to_string(),
-                    }));
-                }
-            }
-        };
+        let admin_settings = AdminSettings::build(&settings.admins);
+        let admins = fetch_admins(&admin_settings, &client).await?;
 
         let admins_by_insee = admins
             .iter()
@@ -173,7 +143,7 @@ mod tests {
         domain::ports::primary::list_documents::ListDocuments,
         utils::docker,
     };
-    use mimirsbrunn::settings::bano2mimir as settings;
+    use mimirsbrunn::settings::{admin_settings::AdminFromCosmogonyFile, bano2mimir as settings};
     use places::addr::Addr;
     use serial_test::serial;
 
@@ -210,7 +180,11 @@ mod tests {
         .iter()
         .collect();
 
-        settings.cosmogony_file = Some(cosmogony_file);
+        settings.admins = Some(AdminFromCosmogonyFile {
+            french_id_retrocompatibility: false,
+            langs: vec!["fr".to_string()],
+            cosmogony_file,
+        });
         let _res = mimirsbrunn::utils::launch::launch_async(move || run(opts, settings)).await;
         assert!(_res.is_ok());
 

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -164,6 +164,8 @@ async fn run(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
     use futures::TryStreamExt;
     use mimir::{
@@ -196,8 +198,21 @@ mod tests {
             cmd: settings::Command::Run,
         };
 
-        let settings = settings::Settings::new(&opts).unwrap();
+        let mut settings = settings::Settings::new(&opts).unwrap();
+        let cosmogony_file: PathBuf = [
+            env!("CARGO_MANIFEST_DIR"),
+            "tests",
+            "fixtures",
+            "cosmogony",
+            "ile-de-france",
+            "ile-de-france.jsonl.gz",
+        ]
+        .iter()
+        .collect();
+
+        settings.cosmogony_file = Some(cosmogony_file);
         let _res = mimirsbrunn::utils::launch::launch_async(move || run(opts, settings)).await;
+        assert!(_res.is_ok());
 
         // Now we query the index we just created. Since it's a small cosmogony file with few entries,
         // we'll just list all the documents in the index, and check them.

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -32,7 +32,8 @@ use clap::Parser;
 use futures::stream::StreamExt;
 use mimir::domain::ports::primary::generate_index::GenerateIndex;
 use mimirsbrunn::{
-    addr_reader::import_addresses_from_input_path, utils::template::update_templates, admin::read_admin_in_cosmogony_file,
+    addr_reader::import_addresses_from_input_path, admin::read_admin_in_cosmogony_file,
+    utils::template::update_templates,
 };
 use snafu::{ResultExt, Snafu};
 use std::sync::Arc;
@@ -108,7 +109,7 @@ async fn run(
     // Lets say we're indexing a single bano department.... we don't need to retrieve
     // the admins for other regions!
     let into_addr = {
-        let admins : Vec<Admin> =  if let Some(cosmogony_file_path) = &settings.cosmogony_file {
+        let admins: Vec<Admin> = if let Some(cosmogony_file_path) = &settings.cosmogony_file {
             read_admin_in_cosmogony_file(
                 cosmogony_file_path,
                 settings.langs.clone(),
@@ -134,7 +135,6 @@ async fn run(
                 }
             }
         };
-       
 
         let admins_by_insee = admins
             .iter()

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -92,14 +92,10 @@ async fn run(
         update_templates(&client, opts.config_dir).await?;
     }
 
-    mimirsbrunn::stops::index_ntfs(
-        &opts.input,
-        &settings,
-        &client,
-    )
-    .await
-    .context(ImportSnafu)
-    .map_err(|err| Box::new(err) as Box<dyn snafu::Error>) // TODO Investigate why the need to cast?
+    mimirsbrunn::stops::index_ntfs(&opts.input, &settings, &client)
+        .await
+        .context(ImportSnafu)
+        .map_err(|err| Box::new(err) as Box<dyn snafu::Error>) // TODO Investigate why the need to cast?
 }
 
 #[cfg(test)]

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -80,7 +80,7 @@ async fn run(
         &settings.elasticsearch.url
     );
     let client = elasticsearch::remote::connection_pool_url(&settings.elasticsearch.url)
-        .conn(settings.elasticsearch)
+        .conn(settings.elasticsearch.clone())
         .await
         .context(ElasticsearchConnectionSnafu)
         .map_err(Box::new)?;
@@ -93,9 +93,8 @@ async fn run(
     }
 
     mimirsbrunn::stops::index_ntfs(
-        opts.input,
-        &settings.container,
-        &settings.physical_mode_weight,
+        &opts.input,
+        &settings,
         &client,
     )
     .await

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -110,7 +110,7 @@ async fn run(
     let into_addr = {
         let admins: Vec<Admin> = if let Some(cosmogony_file_path) = &settings.cosmogony_file {
             read_admin_in_cosmogony_file(
-                &cosmogony_file_path,
+                cosmogony_file_path,
                 settings.langs.clone(),
                 settings.french_id_retrocompatibility,
             )

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -40,7 +40,7 @@ use mimir::{
 };
 use mimirsbrunn::{
     addr_reader::import_addresses_from_input_path, openaddresses::OpenAddress,
-    settings::openaddresses2mimir as settings, utils::template::update_templates,
+    settings::openaddresses2mimir as settings, utils::template::update_templates, admin::read_admin_in_cosmogony_file,
 };
 use places::admin::Admin;
 
@@ -64,6 +64,9 @@ pub enum Error {
     IndexCreation {
         source: mimir::domain::model::error::Error,
     },
+
+    #[snafu(display("Admin Retrieval Error {}", details))]
+    AdminRetrieval { details: String },
 }
 
 fn main() -> Result<(), Error> {
@@ -104,17 +107,32 @@ async fn run(
 
     // Fetch and index admins for `into_addr`
     let into_addr = {
-        let admins: Vec<Admin> = match client.list_documents().await {
-            Ok(stream) => {
-                stream
-                    .map(|admin| admin.expect("could not parse admin"))
-                    .collect()
-                    .await
+        
+        let admins: Vec<Admin> = if let Some(cosmogony_file_path) = &settings.cosmogony_file {
+                read_admin_in_cosmogony_file(
+                    &cosmogony_file_path,
+                    settings.langs.clone(),
+                    settings.french_id_retrocompatibility,
+                )
+                .map_err(|err| Error::AdminRetrieval {
+                    details: err.to_string(),
+                })?
+                .collect()
+
+            } else {
+                match client.list_documents().await {
+                    Ok(stream) => {
+                        stream
+                            .map(|admin| admin.expect("could not parse admin"))
+                            .collect()
+                            .await
+                    }
+                    Err(err) => {
+                        warn!("administratives regions not found in es db. {:?}", err);
+                        Vec::new()
+                    }
             }
-            Err(err) => {
-                warn!("administratives regions not found in es db. {:?}", err);
-                Vec::new()
-            }
+        
         };
         let admins_geofinder = admins.into_iter().collect();
         let id_precision = settings.coordinates.id_precision;

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -178,7 +178,9 @@ mod tests {
             "cosmogony",
             "ile-de-france",
             "ile-de-france.jsonl.gz",
-        ].iter().collect();
+        ]
+        .iter()
+        .collect();
 
         settings.admins = Some(AdminFromCosmogonyFile {
             french_id_retrocompatibility: false,

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -118,9 +118,9 @@ async fn run(
                 warn!("administratives regions not found in es db. {:?}", err);
                 return Err(Box::new(Error::AdminRetrieval { details: err.to_string() }));
             }
-    }
+        }
 
-};
+    };
 
     if settings.streets.import {
         let streets = streets(

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -99,7 +99,7 @@ async fn run(
     let admins_geofinder: AdminGeoFinder =
         if let Some(cosmogony_file_path) = &settings.cosmogony_file {
             read_admin_in_cosmogony_file(
-                &cosmogony_file_path,
+                cosmogony_file_path,
                 settings.langs.clone(),
                 settings.french_id_retrocompatibility,
             )

--- a/src/bin/poi2mimir.rs
+++ b/src/bin/poi2mimir.rs
@@ -52,7 +52,7 @@ async fn run(
         update_templates(&client, opts.config_dir).await?;
     }
 
-    mimirsbrunn::pois::index_pois(opts.input, &client, settings.container).await?;
+    mimirsbrunn::pois::index_pois(opts.input, &client, settings).await?;
 
     Ok(())
 }

--- a/src/pois.rs
+++ b/src/pois.rs
@@ -124,7 +124,7 @@ pub async fn index_pois(
     let admins_geofinder: AdminGeoFinder =
         if let Some(cosmogony_file_path) = &settings.cosmogony_file {
             read_admin_in_cosmogony_file(
-                &cosmogony_file_path,
+                cosmogony_file_path,
                 settings.langs.clone(),
                 settings.french_id_retrocompatibility,
             )

--- a/src/settings/admin_settings.rs
+++ b/src/settings/admin_settings.rs
@@ -1,0 +1,41 @@
+/// This module contains the definition for bano2mimir configuration and command line arguments.
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AdminSettings {
+    // will fetch admins from elasticsearch
+    Elasticsearch,
+    // will fetch admins from a local cosmogony file
+    Local(AdminFromCosmogonyFile),
+}
+
+impl Default for AdminSettings {
+    fn default() -> Self {
+        AdminSettings::Elasticsearch
+    }
+}
+
+impl AdminSettings {
+    pub fn build(opt: &Option<AdminFromCosmogonyFile>) -> Self {
+        match opt {
+            None => AdminSettings::Elasticsearch,
+            Some(config) => AdminSettings::Local(config.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminFromCosmogonyFile {
+    pub cosmogony_file: PathBuf,
+
+    #[serde(default)]
+    pub french_id_retrocompatibility: bool,
+
+    #[serde(default = "default_langs")]
+    pub langs: Vec<String>,
+}
+
+pub fn default_langs() -> Vec<String> {
+    vec!["fr".to_string()]
+}

--- a/src/settings/admin_settings.rs
+++ b/src/settings/admin_settings.rs
@@ -29,11 +29,16 @@ impl AdminSettings {
 pub struct AdminFromCosmogonyFile {
     pub cosmogony_file: PathBuf,
 
-    #[serde(default)]
+    #[serde(default = "default_french_id_retrocompatibility")]
     pub french_id_retrocompatibility: bool,
 
     #[serde(default = "default_langs")]
     pub langs: Vec<String>,
+}
+
+
+pub fn default_french_id_retrocompatibility() -> bool{
+    true
 }
 
 pub fn default_langs() -> Vec<String> {

--- a/src/settings/admin_settings.rs
+++ b/src/settings/admin_settings.rs
@@ -36,8 +36,7 @@ pub struct AdminFromCosmogonyFile {
     pub langs: Vec<String>,
 }
 
-
-pub fn default_french_id_retrocompatibility() -> bool{
+pub fn default_french_id_retrocompatibility() -> bool {
     true
 }
 

--- a/src/settings/bano2mimir.rs
+++ b/src/settings/bano2mimir.rs
@@ -36,6 +36,17 @@ pub struct Settings {
     pub nb_threads: Option<usize>,
     #[serde(default)]
     pub update_templates: bool,
+
+    #[serde(default)]
+    pub french_id_retrocompatibility: bool,
+
+    #[serde(default = "default_langs")]
+    pub langs: Vec<String>,
+    pub cosmogony_file: Option<PathBuf>,
+}
+
+pub fn default_langs() -> Vec<String> {
+    vec!["fr".to_string()]
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/bano2mimir.rs
+++ b/src/settings/bano2mimir.rs
@@ -6,6 +6,8 @@ use std::{env, path::PathBuf};
 
 use mimir::adapters::secondary::elasticsearch::ElasticsearchStorageConfig;
 
+use super::admin_settings::AdminFromCosmogonyFile;
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 
@@ -37,12 +39,9 @@ pub struct Settings {
     #[serde(default)]
     pub update_templates: bool,
 
-    #[serde(default)]
-    pub french_id_retrocompatibility: bool,
-
-    #[serde(default = "default_langs")]
-    pub langs: Vec<String>,
-    pub cosmogony_file: Option<PathBuf>,
+    // will read admins from the file if Some(file)
+    // will fetch admins from Elasticsearch if None
+    pub admins: Option<AdminFromCosmogonyFile>,
 }
 
 pub fn default_langs() -> Vec<String> {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin_settings;
 pub mod bano2mimir;
 pub mod cosmogony2mimir;
 pub mod ctlmimir;

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -35,7 +35,7 @@ pub struct Settings {
     #[serde(default = "default_langs")]
     pub langs: Vec<String>,
 
-    pub cosmogony_file : Option<PathBuf>
+    pub cosmogony_file: Option<PathBuf>,
 }
 
 pub fn default_langs() -> Vec<String> {

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -6,6 +6,8 @@ use std::{env, path::PathBuf};
 
 use mimir::adapters::secondary::elasticsearch::ElasticsearchStorageConfig;
 
+use super::admin_settings::AdminFromCosmogonyFile;
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 
@@ -29,12 +31,9 @@ pub struct Settings {
     #[serde(default)]
     pub update_templates: bool,
 
-    #[serde(default)]
-    pub french_id_retrocompatibility: bool,
-
-    #[serde(default = "default_langs")]
-    pub langs: Vec<String>,
-    pub cosmogony_file: Option<PathBuf>,
+    // will read admins from the file if Some(file)
+    // will fetch admins from Elasticsearch if None
+    pub admins: Option<AdminFromCosmogonyFile>,
 }
 
 pub fn default_langs() -> Vec<String> {

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -29,10 +29,17 @@ pub struct Settings {
     #[serde(default)]
     pub update_templates: bool,
 
+    #[serde(default)]
     pub french_id_retrocompatibility: bool,
+
+    #[serde(default = "default_langs")]
     pub langs: Vec<String>,
 
     pub cosmogony_file : Option<PathBuf>
+}
+
+pub fn default_langs() -> Vec<String> {
+    vec!["fr".to_string()]
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -28,6 +28,11 @@ pub struct Settings {
     pub physical_mode_weight: Option<Vec<PhysicalModeWeight>>,
     #[serde(default)]
     pub update_templates: bool,
+
+    pub french_id_retrocompatibility: bool,
+    pub langs: Vec<String>,
+
+    pub cosmogony_file : Option<PathBuf>
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -34,7 +34,6 @@ pub struct Settings {
 
     #[serde(default = "default_langs")]
     pub langs: Vec<String>,
-
     pub cosmogony_file: Option<PathBuf>,
 }
 

--- a/src/settings/openaddresses2mimir.rs
+++ b/src/settings/openaddresses2mimir.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::{env, path::PathBuf};
 
+use super::admin_settings::AdminFromCosmogonyFile;
 use mimir::adapters::secondary::elasticsearch::ElasticsearchStorageConfig;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -43,12 +44,9 @@ pub struct Settings {
     #[serde(default)]
     pub update_templates: bool,
 
-    #[serde(default)]
-    pub french_id_retrocompatibility: bool,
-
-    #[serde(default = "default_langs")]
-    pub langs: Vec<String>,
-    pub cosmogony_file: Option<PathBuf>,
+    // will read admins from the file if Some(file)
+    // will fetch admins from Elasticsearch if None
+    pub admins: Option<AdminFromCosmogonyFile>,
 }
 
 pub fn default_langs() -> Vec<String> {

--- a/src/settings/openaddresses2mimir.rs
+++ b/src/settings/openaddresses2mimir.rs
@@ -42,6 +42,17 @@ pub struct Settings {
     pub nb_threads: Option<usize>,
     #[serde(default)]
     pub update_templates: bool,
+
+    #[serde(default)]
+    pub french_id_retrocompatibility: bool,
+
+    #[serde(default = "default_langs")]
+    pub langs: Vec<String>,
+    pub cosmogony_file: Option<PathBuf>,
+}
+
+pub fn default_langs() -> Vec<String> {
+    vec!["fr".to_string()]
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -1,3 +1,4 @@
+use super::admin_settings::AdminFromCosmogonyFile;
 /// This module contains the definition for osm2mimir configuration and command line arguments.
 use mimir::adapters::secondary::elasticsearch::ElasticsearchStorageConfig;
 use mimir::domain::model::configuration::ContainerConfig;
@@ -53,12 +54,9 @@ pub struct Settings {
     #[serde(default)]
     pub update_templates: bool,
 
-    #[serde(default)]
-    pub french_id_retrocompatibility: bool,
-
-    #[serde(default = "default_langs")]
-    pub langs: Vec<String>,
-    pub cosmogony_file: Option<PathBuf>,
+    // will read admins from the file if Some(file)
+    // will fetch admins from Elasticsearch if None
+    pub admins: Option<AdminFromCosmogonyFile>,
 }
 
 pub fn default_langs() -> Vec<String> {

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -52,6 +52,17 @@ pub struct Settings {
     pub nb_threads: Option<usize>,
     #[serde(default)]
     pub update_templates: bool,
+
+    #[serde(default)]
+    pub french_id_retrocompatibility: bool,
+
+    #[serde(default = "default_langs")]
+    pub langs: Vec<String>,
+    pub cosmogony_file: Option<PathBuf>,
+}
+
+pub fn default_langs() -> Vec<String> {
+    vec!["fr".to_string()]
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/poi2mimir.rs
+++ b/src/settings/poi2mimir.rs
@@ -8,6 +8,8 @@ use mimir::{
     domain::model::configuration::ContainerConfig,
 };
 
+use super::admin_settings::AdminFromCosmogonyFile;
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 
@@ -34,13 +36,9 @@ pub struct Settings {
     pub nb_threads: Option<usize>,
     #[serde(default)]
     pub update_templates: bool,
-
-    #[serde(default)]
-    pub french_id_retrocompatibility: bool,
-
-    #[serde(default = "default_langs")]
-    pub langs: Vec<String>,
-    pub cosmogony_file: Option<PathBuf>,
+    // will read admins from the file if Some(file)
+    // will fetch admins from Elasticsearch if None
+    pub admins: Option<AdminFromCosmogonyFile>,
 }
 
 pub fn default_langs() -> Vec<String> {

--- a/src/settings/poi2mimir.rs
+++ b/src/settings/poi2mimir.rs
@@ -34,6 +34,17 @@ pub struct Settings {
     pub nb_threads: Option<usize>,
     #[serde(default)]
     pub update_templates: bool,
+
+    #[serde(default)]
+    pub french_id_retrocompatibility: bool,
+
+    #[serde(default = "default_langs")]
+    pub langs: Vec<String>,
+    pub cosmogony_file: Option<PathBuf>,
+}
+
+pub fn default_langs() -> Vec<String> {
+    vec!["fr".to_string()]
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -33,7 +33,7 @@
 use futures::stream::{Stream, TryStreamExt};
 use mimir::domain::model::configuration::{ContainerConfig, PhysicalModeWeight};
 use snafu::{ResultExt, Snafu};
-use std::{collections::HashMap, ops::Deref, path::{PathBuf, Path}, sync::Arc};
+use std::{collections::HashMap, ops::Deref, path::{Path}, sync::Arc};
 use tracing::{info, warn};
 
 use crate::{admin_geofinder::AdminGeoFinder, labels, admin::read_admin_in_cosmogony_file, settings::ntfs2mimir::Settings};

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -181,7 +181,7 @@ where
     match admin_settings {
         AdminSettings::Elasticsearch => attach_stops_to_admins_from_es(stops, client).await,
         AdminSettings::Local(local_config) => {
-            let admins = read_admin_in_cosmogony_file(&local_config).map_err(|err| {
+            let admins = read_admin_in_cosmogony_file(local_config).map_err(|err| {
                 Error::AdminRetrieval {
                     details: err.to_string(),
                 }

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -269,6 +269,7 @@ pub async fn index_ntfs(
     }
     
 
+    info!("Make weights for stops");
     for stop in &mut stops {
         stop.coverages.push(settings.container.dataset.clone());
         make_weight(stop, &stop_areas_weights);

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -201,10 +201,7 @@ async fn attach_stops_to_admins_from_es<'a, It: Iterator<Item = &'a mut Stop>>(
 /// The admins are stored in a quadtree
 /// We attach a stop with all the admins that have a boundary containing
 /// the coordinate of the stop
-fn attach_stops_to_admins_from_iter<'stop, StopIter, AdminIter>(
-    stops: StopIter,
-    admins: AdminIter,
-) 
+fn attach_stops_to_admins_from_iter<'stop, StopIter, AdminIter>(stops: StopIter, admins: AdminIter)
 where
     StopIter: Iterator<Item = &'stop mut Stop>,
     AdminIter: Iterator<Item = Admin>,

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -187,7 +187,8 @@ async fn attach_stops_to_admins_from_es<'a, It: Iterator<Item = &'a mut Stop>>(
                 });
             }
             info!("{} admins retrieved from ES ", admins.len());
-            attach_stops_to_admins_from_iter(stops, admins.into_iter())
+            attach_stops_to_admins_from_iter(stops, admins.into_iter());
+            Ok(())
         }
         Err(_) => Err(Error::AdminRetrieval {
             details: String::from("Could not retrieve admins to enrich stops"),
@@ -203,7 +204,7 @@ async fn attach_stops_to_admins_from_es<'a, It: Iterator<Item = &'a mut Stop>>(
 fn attach_stops_to_admins_from_iter<'stop, StopIter, AdminIter>(
     stops: StopIter,
     admins: AdminIter,
-) -> Result<(), Error>
+) 
 where
     StopIter: Iterator<Item = &'stop mut Stop>,
     AdminIter: Iterator<Item = Admin>,
@@ -228,7 +229,6 @@ where
         nb_unmatched,
         nb_matched + nb_unmatched
     );
-    Ok(())
 }
 
 /// Stores the stops found in the 'input' directory, in Elasticsearch, with the given
@@ -272,14 +272,14 @@ pub async fn index_ntfs(
     info!("Attach stops to admins");
     if let Some(cosmogony_file_path) = &settings.cosmogony_file {
         let admins = read_admin_in_cosmogony_file(
-            &cosmogony_file_path,
+            cosmogony_file_path,
             settings.langs.clone(),
             settings.french_id_retrocompatibility,
         )
         .map_err(|err| Error::AdminRetrieval {
             details: err.to_string(),
         })?;
-        attach_stops_to_admins_from_iter(stops.iter_mut(), admins)?;
+        attach_stops_to_admins_from_iter(stops.iter_mut(), admins);
     } else {
         attach_stops_to_admins_from_es(stops.iter_mut(), client).await?;
     }


### PR DESCRIPTION
Ntfs2mimir needs data about the administrative regions to enrich the stops before putting them into elasticsearch.
The data about the administrative regions  was collected from elasticsearch. 
This collection method causes a non-negligible load on elasticsearch, resulting in various timeouts and errors in bragi.

This PR adds the option to collect the data about administrative region from a local cosmogony file (the same file used to build the "admin" index in cosmogony2mimir).

If a "cosmogony_file" is configured in ntfs2mimir config file, then this file will be used. 
If such configuration is not present, ntfs2mimir will gather administrative regions from elasticsearch, as before.

The same thing is done for the binaries osm2mimir, openaddresses2mimir and poi2mimir.

For more details: https://navitia.atlassian.net/browse/NAV-1339