### PR TITLE
[poi2mimir/osm2mimir] configurable max-distance on address reverse-search for POI

### DIFF
--- a/config/osm2mimir/default.toml
+++ b/config/osm2mimir/default.toml
@@ -31,7 +31,7 @@ update_templates = true
 
 [pois]
   import = false
-  max_distance_reverse = 1000
+  max_distance_reverse = 1000 # in meters
   [pois.config]
     [[pois.config.types]]
       id = "poi_type:amenity:college"

--- a/config/osm2mimir/default.toml
+++ b/config/osm2mimir/default.toml
@@ -31,6 +31,7 @@ update_templates = true
 
 [pois]
   import = false
+  max_distance_reverse = 1000
   [pois.config]
     [[pois.config.types]]
       id = "poi_type:amenity:college"

--- a/config/poi2mimir/default.toml
+++ b/config/poi2mimir/default.toml
@@ -1,6 +1,6 @@
 nb_threads = 2
 update_templates = true
-max_distance_reverse = 1000
+max_distance_reverse = 1000 # in meters
 
 # If the admins sections is present, the admins will be read in the cosmogony file.
 # Otherwise, admins will be fetched  from elasticsearch

--- a/config/poi2mimir/default.toml
+++ b/config/poi2mimir/default.toml
@@ -1,5 +1,6 @@
 nb_threads = 2
 update_templates = true
+max_distance_reverse = 1000
 
 # If the admins sections is present, the admins will be read in the cosmogony file.
 # Otherwise, admins will be fetched  from elasticsearch

--- a/libs/mimir/src/utils/deserialize.rs
+++ b/libs/mimir/src/utils/deserialize.rs
@@ -16,3 +16,7 @@ where
     let ms: u64 = Deserialize::deserialize(deserializer)?;
     Ok(Some(Duration::from_millis(ms)))
 }
+
+pub fn usize1000() -> usize {
+    1000
+}

--- a/libs/tests/src/osm.rs
+++ b/libs/tests/src/osm.rs
@@ -122,7 +122,9 @@ pub async fn index_pois(
 
     let pois: Vec<Poi> = futures::stream::iter(pois)
         .map(mimirsbrunn::osm_reader::poi::compute_weight)
-        .then(|poi| mimirsbrunn::osm_reader::poi::add_address(client, poi))
+        .then(|poi| {
+            mimirsbrunn::osm_reader::poi::add_address(client, poi, config.pois.max_distance_reverse)
+        })
         .collect()
         .await;
     let _ = client

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -118,6 +118,7 @@ async fn run(
             &settings.pois.config.clone().unwrap_or_default(),
             &client,
             &settings.container_poi,
+            settings.pois.max_distance_reverse,
         )
         .await?;
     }
@@ -150,6 +151,7 @@ async fn import_pois(
     poi_config: &mimirsbrunn::osm_reader::poi::PoiConfig,
     client: &ElasticsearchStorage,
     config: &ContainerConfig,
+    max_distance_reverse: usize,
 ) -> Result<(), Error> {
     // This function rely on AdminGeoFinder::get_objs_and_deps
     // which use all available cpu/cores to decode osm file and cannot be limited by tokio runtime
@@ -158,7 +160,7 @@ async fn import_pois(
 
     let pois: Vec<places::poi::Poi> = futures::stream::iter(pois)
         .map(mimirsbrunn::osm_reader::poi::compute_weight)
-        .then(|poi| mimirsbrunn::osm_reader::poi::add_address(client, poi))
+        .then(|poi| mimirsbrunn::osm_reader::poi::add_address(client, poi, max_distance_reverse))
         .collect()
         .await;
 

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -278,14 +278,13 @@ pub fn compute_weight(poi: Poi) -> Poi {
 }
 
 // FIXME Return a Result
-pub async fn add_address<T>(backend: &T, poi: Poi) -> Poi
+pub async fn add_address<T>(backend: &T, poi: Poi, max_distance_reverse: usize) -> Poi
 where
     T: SearchDocuments,
     T::Document: Into<serde_json::Value>,
 {
-    // FIXME 1km automagick
     let reverse = mimir::adapters::primary::common::dsl::build_reverse_query(
-        "1km",
+        format!("{}m", max_distance_reverse).as_ref(),
         poi.coord.lat(),
         poi.coord.lon(),
     );

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -28,6 +28,7 @@ pub struct Street {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Poi {
     pub import: bool,
+    pub max_distance_reverse: usize,
     pub config: Option<crate::osm_reader::poi::PoiConfig>,
 }
 

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -2,6 +2,7 @@ use super::admin_settings::AdminFromCosmogonyFile;
 /// This module contains the definition for osm2mimir configuration and command line arguments.
 use mimir::adapters::secondary::elasticsearch::ElasticsearchStorageConfig;
 use mimir::domain::model::configuration::ContainerConfig;
+use mimir::utils::deserialize::usize1000;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::{env, path::PathBuf};
@@ -28,7 +29,8 @@ pub struct Street {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Poi {
     pub import: bool,
-    pub max_distance_reverse: usize,
+    #[serde(default = "usize1000")]
+    pub max_distance_reverse: usize, // in meters
     pub config: Option<crate::osm_reader::poi::PoiConfig>,
 }
 

--- a/src/settings/poi2mimir.rs
+++ b/src/settings/poi2mimir.rs
@@ -5,7 +5,7 @@ use std::{env, path::PathBuf};
 
 use mimir::{
     adapters::secondary::elasticsearch::ElasticsearchStorageConfig,
-    domain::model::configuration::ContainerConfig,
+    domain::model::configuration::ContainerConfig, utils::deserialize::usize1000,
 };
 
 use super::admin_settings::AdminFromCosmogonyFile;
@@ -39,7 +39,8 @@ pub struct Settings {
     // will read admins from the file if Some(file)
     // will fetch admins from Elasticsearch if None
     pub admins: Option<AdminFromCosmogonyFile>,
-    pub max_distance_reverse: usize,
+    #[serde(default = "usize1000")]
+    pub max_distance_reverse: usize, // in meters
 }
 
 pub fn default_langs() -> Vec<String> {

--- a/src/settings/poi2mimir.rs
+++ b/src/settings/poi2mimir.rs
@@ -39,6 +39,7 @@ pub struct Settings {
     // will read admins from the file if Some(file)
     // will fetch admins from Elasticsearch if None
     pub admins: Option<AdminFromCosmogonyFile>,
+    pub max_distance_reverse: usize,
 }
 
 pub fn default_langs() -> Vec<String> {


### PR DESCRIPTION
For POI integration, make max-distance configurable on address reverse-search.
This maximum defaults to 1000 m now, same as before for `osm2mimir`.
For `poi2mimir`, it was 50 m previously (too short in some cases).

Related to internal ticket: https://navitia.atlassian.net/browse/NAV-1383

:heavy_check_mark: Hand-tested that this corrects our precise cases
:heavy_check_mark: This does not seem to impact integration perfs for `poi2mimir` (although machine used to test is slow by default)

Bonus #codesmell: removed 2 `automagic` occurrences :tada: 