### PR TITLE
feat: use an integer gauge for counting request in flight

### DIFF
--- a/libs/mimir/src/adapters/primary/bragi/prometheus_handler.rs
+++ b/libs/mimir/src/adapters/primary/bragi/prometheus_handler.rs
@@ -51,7 +51,7 @@ lazy_static::lazy_static! {
     )
     .unwrap();
 
-    static ref HTTP_IN_FLIGHT: prometheus::Gauge = prometheus::register_gauge!(
+    static ref HTTP_IN_FLIGHT: prometheus::IntGauge = prometheus::register_int_gauge!(
         "bragi_http_requests_in_flight",
         "current number of http request being served"
     )
@@ -79,7 +79,7 @@ pub fn update_metrics(info: warp::log::Info) {
         .with_label_values(&[&handler, &method, &status])
         .inc();
 
-    HTTP_IN_FLIGHT.dec();
+    HTTP_IN_FLIGHT.inc();
 }
 
 #[cfg(not(feature = "prometheus"))]


### PR DESCRIPTION
A minima, we should increment the number, not decrement it.

And let's use an integer gauge that is susceptible to get better performance (see [documentation](https://docs.rs/prometheus/latest/prometheus/type.IntGauge.html)).

Also, `Gauge` uses `AtomicF64` that implement increment with [a fallible addition](https://docs.rs/prometheus/0.13.0/src/prometheus/atomic64.rs.html#112).

`IntGauge` uses `AtomicI64` which itself use [`std::sync::atomic::AtomicI64::fetch_add`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicI64.html#method.fetch_add): `fetch_add` does not panic but [wraps on overflow](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicI64.html#method.fetch_add).