### PR TITLE
remove Send + Sync on streams

### DIFF
--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -533,7 +533,7 @@ impl ElasticsearchStorage {
     ) -> Result<InsertStats, Error>
     where
         D: Document + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync,
+        S: Stream<Item = D>,
     {
         let stats = self
             .bulk(
@@ -559,7 +559,7 @@ impl ElasticsearchStorage {
     ) -> Result<InsertStats, Error>
     where
         D: Serialize + Send + Sync + 'static,
-        S: Stream<Item = (String, D)> + Send + Sync,
+        S: Stream<Item = (String, D)>,
     {
         let stats = self
             .bulk(
@@ -578,7 +578,7 @@ impl ElasticsearchStorage {
     async fn bulk<D, S>(&self, index: String, documents: S) -> Result<InsertStats, Error>
     where
         D: Serialize + Send + Sync + 'static,
-        S: Stream<Item = BulkOperation<D>> + Send + Sync,
+        S: Stream<Item = BulkOperation<D>>,
     {
         let stats = documents
             .chunks(self.config.insertion_chunk_size)

--- a/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
@@ -24,7 +24,7 @@ use crate::domain::{
 };
 use common::document::Document;
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'s> Storage<'s> for ElasticsearchStorage {
     // This function delegates to elasticsearch the creation of the index. But since this
     // function returns nothing, we follow with a find index to return some details to the caller.
@@ -73,7 +73,7 @@ impl<'s> Storage<'s> for ElasticsearchStorage {
     ) -> Result<InsertStats, StorageError>
     where
         D: Document + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 's,
+        S: Stream<Item = D> + 's,
     {
         self.add_pipeline(
             include_str!(concat!(
@@ -120,7 +120,7 @@ impl<'s> Storage<'s> for ElasticsearchStorage {
         operations: S,
     ) -> Result<InsertStats, StorageError>
     where
-        S: Stream<Item = (String, Vec<UpdateOperation>)> + Send + Sync + 's,
+        S: Stream<Item = (String, Vec<UpdateOperation>)> + 's,
     {
         #[derive(Clone, Serialize)]
         #[serde(into = "serde_json::Value")]

--- a/libs/mimir/src/domain/ports/primary/configure_backend.rs
+++ b/libs/mimir/src/domain/ports/primary/configure_backend.rs
@@ -2,15 +2,15 @@ use crate::domain::{model::error::Error as ModelError, ports::secondary::storage
 use async_trait::async_trait;
 use config::Config;
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait ConfigureBackend {
     async fn configure(&self, directive: String, config: Config) -> Result<(), ModelError>;
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<T> ConfigureBackend for T
 where
-    T: Storage<'static> + Send + Sync + 'static,
+    T: Storage<'static>,
 {
     async fn configure(&self, directive: String, config: Config) -> Result<(), ModelError> {
         self.configure(directive, config)

--- a/libs/mimir/src/domain/ports/primary/generate_index.rs
+++ b/libs/mimir/src/domain/ports/primary/generate_index.rs
@@ -34,7 +34,7 @@ where
     ) -> Result<Index, ModelError>
     where
         D: ContainerDocument + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 's;
+        S: Stream<Item = D> + 's;
 }
 
 #[async_trait(?Send)]
@@ -73,7 +73,7 @@ where
     ) -> Result<Index, ModelError>
     where
         D: ContainerDocument + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 's,
+        S: Stream<Item = D> + 's,
     {
         self.init_container(config)
             .await?
@@ -107,7 +107,7 @@ where
     #[tracing::instrument(skip(self, documents))]
     pub async fn insert_documents(
         self,
-        documents: impl Stream<Item = D> + Send + Sync + 's,
+        documents: impl Stream<Item = D> + 's,
     ) -> Result<ContainerGenerator<'a, D, T>, ModelError> {
         let stats = self
             .storage
@@ -123,7 +123,7 @@ where
     #[tracing::instrument(skip(self, updates))]
     pub async fn update_documents(
         self,
-        updates: impl Stream<Item = (String, Vec<UpdateOperation>)> + Sync + 's,
+        updates: impl Stream<Item = (String, Vec<UpdateOperation>)> + 's,
     ) -> Result<ContainerGenerator<'a, D, T>, ModelError> {
         let stats = self
             .storage

--- a/libs/mimir/src/domain/ports/primary/generate_index.rs
+++ b/libs/mimir/src/domain/ports/primary/generate_index.rs
@@ -123,7 +123,7 @@ where
     #[tracing::instrument(skip(self, updates))]
     pub async fn update_documents(
         self,
-        updates: impl Stream<Item = (String, Vec<UpdateOperation>)> + Send + Sync + 's,
+        updates: impl Stream<Item = (String, Vec<UpdateOperation>)> + Sync + 's,
     ) -> Result<ContainerGenerator<'a, D, T>, ModelError> {
         let stats = self
             .storage

--- a/libs/mimir/src/domain/ports/secondary/storage.rs
+++ b/libs/mimir/src/domain/ports/secondary/storage.rs
@@ -44,7 +44,7 @@ pub enum Error {
     UnrecognizedDirective { details: String },
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait Storage<'s> {
     async fn create_container(&self, config: &ContainerConfig) -> Result<Index, Error>;
 
@@ -63,7 +63,7 @@ pub trait Storage<'s> {
 
     async fn update_documents<S>(&self, index: String, operations: S) -> Result<InsertStats, Error>
     where
-        S: Stream<Item = (String, Vec<UpdateOperation>)> + Send + Sync + 's;
+        S: Stream<Item = (String, Vec<UpdateOperation>)> + 's;
 
     async fn publish_index(
         &self,
@@ -74,7 +74,7 @@ pub trait Storage<'s> {
     async fn configure(&self, directive: String, config: Config) -> Result<(), Error>;
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'s, T: ?Sized> Storage<'s> for Box<T>
 where
     T: Storage<'s> + Send + Sync,
@@ -105,7 +105,7 @@ where
 
     async fn update_documents<S>(&self, index: String, operations: S) -> Result<InsertStats, Error>
     where
-        S: Stream<Item = (String, Vec<UpdateOperation>)> + Send + Sync + 's,
+        S: Stream<Item = (String, Vec<UpdateOperation>)> + 's,
     {
         (**self).update_documents(index, operations).await
     }

--- a/libs/mimir/src/domain/ports/secondary/storage.rs
+++ b/libs/mimir/src/domain/ports/secondary/storage.rs
@@ -59,7 +59,7 @@ pub trait Storage<'s> {
     ) -> Result<InsertStats, Error>
     where
         D: Document + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 's;
+        S: Stream<Item = D> + 's;
 
     async fn update_documents<S>(&self, index: String, operations: S) -> Result<InsertStats, Error>
     where
@@ -98,7 +98,7 @@ where
     ) -> Result<InsertStats, Error>
     where
         D: Document + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 's,
+        S: Stream<Item = D> + 's,
     {
         (**self).insert_documents(index, documents).await
     }


### PR DESCRIPTION
This doesn't change anything here (except maybe for a bit of
simplification) but it makes mimir more flexible as a library in other
repos.