### PR TITLE
ci: force installation on old Debian versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install requirements
         run: |
           apt-get update
-          apt-get install -y curl wget build-essential
-          apt-get install -y ${{ matrix.packages }}
+          apt-get install --force-yes curl wget build-essential
+          apt-get install --force-yes ${{ matrix.packages }}
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
@@ -56,7 +56,7 @@ jobs:
       - name: slack notification (the job has failed)
         if: failure()
         run: |
-          apt install -y httpie
+          apt install --force-yes httpie
           echo '{"text":":Warning: Github Actions: build packages for branch release failed  ! (https://github.com/hove-io/mimirsbrunn/actions/workflows/release.yml)."}' | http --json POST ${{secrets.SLACK_NAVITIA_AUTOCOMPLETE_TEAM_URL}}
 
   publish:
@@ -71,7 +71,7 @@ jobs:
       - name: install  dependency
         run: |
           sudo apt update
-          sudo apt install -y httpie
+          sudo apt install --force-yes httpie
 
       - name: run publish job & slack notification (the job has successed)
         run: |

--- a/.github/workflows/release7.yml
+++ b/.github/workflows/release7.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Install requirements
         run: |
           apt-get update
-          apt-get install -y curl wget build-essential
-          apt-get install -y ${{ matrix.packages }}
+          apt-get install --force-yes curl wget build-essential
+          apt-get install --force-yes ${{ matrix.packages }}
       # TODO :
       # Remove this step after ES migration 2->7.
       # We need it to make version 2 and 7 coexist.
@@ -67,7 +67,7 @@ jobs:
       - name: slack notification (the job has failed)
         if: failure()
         run: |
-          apt install -y httpie
+          apt install --force-yes httpie
           echo '{"text":":Warning: Github Actions: build packages for branch release failed  ! (https://github.com/hove-io/mimirsbrunn/actions/workflows/release.yml)."}' | http --json POST ${{secrets.SLACK_NAVITIA_AUTOCOMPLETE_TEAM_URL}}
 
   publish:
@@ -82,7 +82,7 @@ jobs:
       - name: install  dependency
         run: |
           sudo apt update
-          sudo apt install -y httpie
+          sudo apt install --force-yes httpie
 
       - name: run publish job & slack notification (the job has successed)
         run: |


### PR DESCRIPTION
We will eventually upgrade Debian version to up-to-date Debian versions (probably Debian 11). But this is going to be part of a larger effort.

At the moment, let's fix it as in [`navitia`](https://github.com/hove-io/navitia/pull/3859) and [`navitia-docker-compose`](https://github.com/hove-io/navitia-docker-compose/pull/147).