### PR TITLE
ci: use evaluated environment variable instead of raw

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,9 +71,9 @@ jobs:
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]
           then
-            echo 'CLIENT_PAYLOAD={ "tag": "${GITHUB_REF_NAME}" }' >> ${GITHUB_ENV}
+            echo 'CLIENT_PAYLOAD={ "tag": "${{ env.GITHUB_REF_NAME }}" }' >> ${GITHUB_ENV}
           else : 
-            echo 'CLIENT_PAYLOAD={ "branch": "${GITHUB_REF_NAME}" }' >> ${GITHUB_ENV}
+            echo 'CLIENT_PAYLOAD={ "branch": "${{ env.GITHUB_REF_NAME }}" }' >> ${GITHUB_ENV}
           fi
 
       - name: Repository Dispatch 'bragi-aws-assets'


### PR DESCRIPTION
Using single quotes `'`, the string `$GITHUB_REF_NAME` was not evaluated and was sent as is to `hove-io/bragi-aws-assets` which actually inserted it in Bash and evaluated it as `main` (the name of the default branch in `hove-io/bragi-aws-assets`), provoking a `docker pull bragi:main` which didn't exist, obviously. Note that using `${{ ... }}` should be evaluated before everything, as this is the Github Actions templating language.