### PR TITLE
ci: remove jenkins jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,7 @@ jobs:
           sudo apt update
           sudo apt install --yes --force-yes httpie
 
-      - name: run publish job & slack notification (the job has successed)
+      - name: slack notification (the job succeeded)
         run: |
-          http --ignore-stdin -v -f POST https://${{secrets.JENKINS_TOKEN}}@jenkins-core.canaltp.fr/job/publish_autocomplete_packages/
           version=$(make version)
           echo '{"text":":information_source: Github Actions: build packages for branch release succeded - New packages mimir ' $VERSION 'is available"}' | http --json POST ${{secrets.SLACK_NAVITIA_AUTOCOMPLETE_TEAM_URL}}

--- a/.github/workflows/release7.yml
+++ b/.github/workflows/release7.yml
@@ -84,8 +84,7 @@ jobs:
           sudo apt update
           sudo apt install --yes --force-yes httpie
 
-      - name: run publish job & slack notification (the job has successed)
+      - name: slack notification (the job succeeded)
         run: |
-          http --ignore-stdin -v -f POST https://${{secrets.JENKINS_TOKEN}}@jenkins-core.canaltp.fr/job/publish_autocomplete_packages/
           version=$(make version)
           echo '{"text":":information_source: Github Actions: build packages for branch release succeded - New packages mimir ' $VERSION 'is available"}' | http --json POST ${{secrets.SLACK_NAVITIA_AUTOCOMPLETE_TEAM_URL}}


### PR DESCRIPTION
This Jenkins job was triggered to gather Debian packages artifacts and push them to an FTP for further deployments. We do not need that anymore (deployment changed).