### PR TITLE
feat: add 'elision' to standard labels

### DIFF
--- a/config/elasticsearch/templates/components/mimir-base.json
+++ b/config/elasticsearch/templates/components/mimir-base.json
@@ -147,7 +147,7 @@
           "label": {
             "type": "text",
             "index_options": "docs",
-            "analyzer": "word",
+            "analyzer": "word_elision",
             "copy_to": "full_label",
             "fields": {
               "prefix": {
@@ -170,7 +170,7 @@
           "full_label": {
             "type": "text",
             "index_options": "docs",
-            "analyzer": "word",
+            "analyzer": "word_elision",
             "fields": {
               "prefix": {
                 "type": "text",
@@ -192,7 +192,7 @@
           "name": {
             "type": "text",
             "index_options": "docs",
-            "analyzer": "word",
+            "analyzer": "word_elision",
             "fields": {
               "prefix": {
                 "type": "text",


### PR DESCRIPTION
Elision was implemented, a few months back, in https://github.com/hove-io/mimirsbrunn/pull/430, then used in https://github.com/hove-io/mimirsbrunn/pull/478 with some tests added to avoid regression.

Sadly, during a big refactorization, these tests have been removed in https://github.com/hove-io/mimirsbrunn/commit/fa7f0a899036b1675f74204ca3056f15d78a212c.

In the meantime, the project transitioned from ElasticSearch 2 to ElasticSearch 7 which induce a massive reorganization and rewrite of all the ElasticSearch configurations (into templates). And we can see that elisions that were present in https://github.com/hove-io/mimirsbrunn/blob/6d4d35ac6967bc27157b34733c5a1145c2b3dd00/config/stop_settings.json#L109 for example, disappeared in https://github.com/hove-io/mimirsbrunn/blob/master/config/elasticsearch/templates/components/mimir-base.json#L150 to be replaced by a more simple `analyzer`.

Since the `word_elision` analyzer still exists in https://github.com/hove-io/mimirsbrunn/blob/master/config/elasticsearch/templates/components/mimir-base.json#L17-L26, it's just about plugging it again.

:warning: No test have been added yet, but it seems the tests are in a very weird shape. Especiallyn the `end_to_end` tests  basically fails (you can take a look in the logs of Github Actions). But, for an unknown reason, they do not return with a failure exit code (meaning Github Actions don't understand it fails). CI :heavy_check_mark: but for wrong reasons. Need more work to figure that out.