### PR TITLE
feat: add possibility to deactivate ANSI formatting for logs

### DIFF
--- a/libs/mimir/src/adapters/primary/bragi/routes.rs
+++ b/libs/mimir/src/adapters/primary/bragi/routes.rs
@@ -100,7 +100,7 @@ pub fn validate_geojson_body(
 
 pub async fn report_invalid(rejection: Rejection) -> Result<impl Reply, Infallible> {
     let reply = if let Some(err) = rejection.find::<warp::reject::InvalidQuery>() {
-        tracing::info!("Invalid query {:?}", err);
+        tracing::warn!("Invalid query {:?}", err);
         warp::reply::with_status(
             warp::reply::json(&ApiError {
                 short: "invalid query".to_string(),
@@ -109,7 +109,7 @@ pub async fn report_invalid(rejection: Rejection) -> Result<impl Reply, Infallib
             StatusCode::BAD_REQUEST,
         )
     } else if let Some(err) = rejection.find::<InvalidRequest>() {
-        tracing::info!("Invalid request {:?}", err);
+        tracing::warn!("Invalid request {:?}", err);
         warp::reply::with_status(
             warp::reply::json(&ApiError {
                 short: "validation error".to_string(),
@@ -118,7 +118,7 @@ pub async fn report_invalid(rejection: Rejection) -> Result<impl Reply, Infallib
             StatusCode::BAD_REQUEST,
         )
     } else if let Some(err) = rejection.find::<InternalError>() {
-        tracing::info!("Internal error {:?}", err);
+        tracing::warn!("Internal error {:?}", err);
         let short = match err.reason {
             InternalErrorReason::ObjectNotFoundError => "Unable to find object".to_string(),
             _ => "query error".to_string(),
@@ -131,7 +131,7 @@ pub async fn report_invalid(rejection: Rejection) -> Result<impl Reply, Infallib
             StatusCode::BAD_REQUEST,
         )
     } else if let Some(err) = rejection.find::<MethodNotAllowed>() {
-        tracing::info!("MethodNotAllowed {:?}", err);
+        tracing::warn!("MethodNotAllowed {:?}", err);
         warp::reply::with_status(
             warp::reply::json(&ApiError {
                 short: "no route".to_string(),
@@ -140,7 +140,7 @@ pub async fn report_invalid(rejection: Rejection) -> Result<impl Reply, Infallib
             StatusCode::NOT_FOUND,
         )
     } else {
-        tracing::info!("Internal server error");
+        tracing::warn!("Internal server error");
         warp::reply::with_status(
             warp::reply::json(&ApiError {
                 short: "INTERNAL_SERVER_ERROR".to_string(),

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -27,6 +27,7 @@ pub fn logger_init() -> Result<tracing_appender::non_blocking::WorkerGuard, Erro
     let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
 
     let event_format = tracing_subscriber::fmt::format()
+        .with_ansi(!std::option_env!("NO_COLOR").is_some())
         .with_target(false) // Don't include event targets.
         .compact();
 

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -27,7 +27,7 @@ pub fn logger_init() -> Result<tracing_appender::non_blocking::WorkerGuard, Erro
     let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
 
     let event_format = tracing_subscriber::fmt::format()
-        .with_ansi(!std::option_env!("NO_COLOR").is_some())
+        .with_ansi(std::option_env!("NO_COLOR").is_none())
         .with_target(false) // Don't include event targets.
         .compact();
 

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -27,7 +27,7 @@ pub fn logger_init() -> Result<tracing_appender::non_blocking::WorkerGuard, Erro
     let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
 
     let event_format = tracing_subscriber::fmt::format()
-        .with_ansi(std::option_env!("NO_COLOR").is_none())
+        .with_ansi(std::option_env!("NO_ANSI").is_none())
         .with_target(false) // Don't include event targets.
         .compact();
 


### PR DESCRIPTION
Will give the ability to deactivate ANSI formatting (give some coloring and bold for example) when necessary (see screenshot below with all the `[2m` and other `[32m`).

![image](https://user-images.githubusercontent.com/2520723/224003708-e221ec9b-095e-4045-b40d-add51875859c.png)

When `NO_COLOR` variable is defined (whatever the value you put in it), then ANSI will be deactivated and it's just going to be raw text.

Note: also modifying level of log for some errors to `WARN` (they are not unrecoverable errors from `bragi` point of view so `WARN` is enough).