### PR TITLE
Fix serialize children

### DIFF
--- a/libs/places/src/poi.rs
+++ b/libs/places/src/poi.rs
@@ -39,6 +39,7 @@ pub struct Poi {
     pub distance: Option<u32>,
 
     pub context: Option<Context>,
+    #[serde(default)]
     pub children: Vec<Poi>,
 }
 


### PR DESCRIPTION
Fix error: **request: Internal error InternalError { reason: SerializationError, info: "missing field `children`" }**