### PR TITLE
ci: use prebuild navitia images

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,24 +11,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: jessie
-            packages: pkg-config libssl-dev
+          - container: navitia/debian8_dev
             rust: "1.66"
 
-          - version: buster
-            packages: pkg-config libssl-dev
+          - container: navitia/debian11_dev
             rust: "1.66"
 
-    container: debian:${{matrix.version}}
+    container: ${{ matrix.container }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install requirements
-        run: |
-          apt-get update
-          apt-get install --yes --force-yes curl wget build-essential
-          apt-get install --yes --force-yes ${{ matrix.packages }}
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/master7.yml
+++ b/.github/workflows/master7.yml
@@ -11,24 +11,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: jessie
-            packages: pkg-config libssl-dev
+          - container: navitia/debian8_dev
             rust: "1.66"
 
-          - version: buster
-            packages: pkg-config libssl-dev
+          - container: navitia/debian11_dev
             rust: "1.66"
 
-    container: debian:${{matrix.version}}
+    container: ${{ matrix.container }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install requirements
-        run: |
-          apt-get update
-          apt-get install --yes --force-yes curl wget build-essential
-          apt-get install --yes --force-yes ${{ matrix.packages }}
       # TODO :
       # Remove this step after ES migration 2->7.
       # We need it to make version 2 and 7 coexist.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,24 +15,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: jessie
-            packages: pkg-config libssl-dev
+          - container: navitia/debian8_dev
             rust: "1.66"
 
-          - version: buster
-            packages: pkg-config libssl-dev
+          - container: navitia/debian11_dev
             rust: "1.66"
 
-    container: debian:${{matrix.version}}
+    container: ${{ matrix.container }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install requirements
-        run: |
-          apt-get update
-          apt-get install --yes --force-yes curl wget build-essential
-          apt-get install --yes --force-yes ${{ matrix.packages }}
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release7.yml
+++ b/.github/workflows/release7.yml
@@ -15,25 +15,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: jessie
-            packages: pkg-config libssl-dev
+          - container: navitia/debian8_dev
             rust: "1.66"
 
-          - version: buster
-            packages: pkg-config libssl-dev
+          - container: navitia/debian11_dev
             rust: "1.66"
 
 
-    container: debian:${{matrix.version}}
+    container: ${{ matrix.container }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install requirements
-        run: |
-          apt-get update
-          apt-get install --yes --force-yes curl wget build-essential
-          apt-get install --yes --force-yes ${{ matrix.packages }}
       # TODO :
       # Remove this step after ES migration 2->7.
       # We need it to make version 2 and 7 coexist.


### PR DESCRIPTION
Debian Jessie 8 is now too old and the repositories have been archived. It starts to be really difficult to build anything with it. For the time being, we still need Debian packages built on Debian 8 (for `tyr-worker` on `navitia`). It seems that `navitia/debian8_dev` has everything we need.

Here is [a build that works](https://github.com/hove-io/mimirsbrunn/actions/runs/4552908750) (I simulated a build on `master` with [this commit](https://github.com/hove-io/mimirsbrunn/commit/9d328c553f9155bb7f7a3c8e4d7240b289dbc807)).