### PR TITLE
ci: fix the call to build_dev.sh

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,13 +11,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - container: navitia/debian8_dev
+          - debian_version: 8
             rust: "1.66"
 
-          - container: navitia/debian11_dev
+          - debian_version: 11
             rust: "1.66"
 
-    container: ${{ matrix.container }}
+    container: navitia/debian${{ matrix.debian_version }}_dev
 
     steps:
       - name: Checkout
@@ -29,7 +29,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
       - name: Build package
-        run: ./scripts/build_deb.sh ${{ matrix.version }}
+        run: ./scripts/build_deb.sh ${{ matrix.debian_version }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/master7.yml
+++ b/.github/workflows/master7.yml
@@ -11,13 +11,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - container: navitia/debian8_dev
+          - debian_version: 8
             rust: "1.66"
 
-          - container: navitia/debian11_dev
+          - debian_version: 11
             rust: "1.66"
 
-    container: ${{ matrix.container }}
+    container: navitia/debian${{ matrix.debian_version }}_dev
 
     steps:
       - name: Checkout
@@ -40,7 +40,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Build package
-        run: ./scripts/build_deb.sh ${{ matrix.version }} 7
+        run: ./scripts/build_deb.sh ${{ matrix.debian_version }} 7
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - container: navitia/debian8_dev
+          - debian_version: 8
             rust: "1.66"
 
-          - container: navitia/debian11_dev
+          - debian_version: 11
             rust: "1.66"
 
-    container: ${{ matrix.container }}
+    container: navitia/debian${{ matrix.debian_version }}_dev
 
     steps:
       - name: Checkout
@@ -33,7 +33,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
       - name: Build package
-        run: ./scripts/build_deb.sh ${{ matrix.version }}
+        run: ./scripts/build_deb.sh ${{ matrix.debian_version }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release7.yml
+++ b/.github/workflows/release7.yml
@@ -15,14 +15,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - container: navitia/debian8_dev
+          - debian_version: 8
             rust: "1.66"
 
-          - container: navitia/debian11_dev
+          - debian_version: 11
             rust: "1.66"
 
 
-    container: ${{ matrix.container }}
+    container: navitia/debian${{ matrix.debian_version }}_dev
 
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
       - name: Build package
-        run: ./scripts/build_deb.sh ${{ matrix.version }} 7
+        run: ./scripts/build_deb.sh debian${{ matrix.debian_version }} 7
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The `matrix.version` was also used inside `build_dev.sh` (although only to name a temporary directory to make the build :shrug:). I hope this is the latest CI fix :upside_down_face: 