### PR TITLE
ci: make the name of the Debian packages back to the old name

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,9 +12,11 @@ jobs:
       matrix:
         include:
           - debian_version: 8
+            debian_name: jessie
             rust: "1.66"
 
           - debian_version: 11
+            debian_name: bullseye
             rust: "1.66"
 
     container: navitia/debian${{ matrix.debian_version }}_dev
@@ -29,7 +31,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
       - name: Build package
-        run: ./scripts/build_deb.sh ${{ matrix.debian_version }}
+        run: ./scripts/build_deb.sh ${{ matrix.debian_name }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/master7.yml
+++ b/.github/workflows/master7.yml
@@ -12,9 +12,11 @@ jobs:
       matrix:
         include:
           - debian_version: 8
+            debian_name: jessie
             rust: "1.66"
 
           - debian_version: 11
+            debian_name: bullseye
             rust: "1.66"
 
     container: navitia/debian${{ matrix.debian_version }}_dev
@@ -40,7 +42,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Build package
-        run: ./scripts/build_deb.sh ${{ matrix.debian_version }} 7
+        run: ./scripts/build_deb.sh ${{ matrix.debian_name }} 7
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,11 @@ jobs:
       matrix:
         include:
           - debian_version: 8
+            debian_name: jessie
             rust: "1.66"
 
           - debian_version: 11
+            debian_name: bullseye
             rust: "1.66"
 
     container: navitia/debian${{ matrix.debian_version }}_dev
@@ -33,7 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
       - name: Build package
-        run: ./scripts/build_deb.sh ${{ matrix.debian_version }}
+        run: ./scripts/build_deb.sh ${{ matrix.debian_name }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release7.yml
+++ b/.github/workflows/release7.yml
@@ -16,9 +16,11 @@ jobs:
       matrix:
         include:
           - debian_version: 8
+            debian_name: jessie
             rust: "1.66"
 
           - debian_version: 11
+            debian_name: bullseye
             rust: "1.66"
 
 
@@ -44,7 +46,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
       - name: Build package
-        run: ./scripts/build_deb.sh debian${{ matrix.debian_version }} 7
+        run: ./scripts/build_deb.sh debian${{ matrix.debian_name }} 7
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Before, Debian packages were named `mimirsbrunn-jessie-v2.12.0.deb`. But with recent changes in the CI, and particularly with 070ea0f and 25aebd1, the new names of the Debian packages was changed to `mimirsbrunn-8-v2.12.0.deb`.

This PR brings back the old naming scheme.