### PR TITLE
ci: fix renaming of binaries with a suffix

### DIFF
--- a/.github/workflows/master7.yml
+++ b/.github/workflows/master7.yml
@@ -24,16 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      # TODO :
-      # Remove this step after ES migration 2->7.
-      # We need it to make version 2 and 7 coexist.
-      # Be careful, binaries will not have the same name !
-      - name: Temporary rename binaries with 7
-        run: |
-          for exec in bragi bano2mimir cosmogony2mimir ctlmimir openaddresses2mimir osm2mimir poi2mimir ntfs2mimir query; do
-            sed -i -e "s/^name\s*=\s*\"$exec\"/name = \"${exec}7\"/" Cargo.toml;
-          done
-
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release7.yml
+++ b/.github/workflows/release7.yml
@@ -29,16 +29,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      # TODO :
-      # Remove this step after ES migration 2->7.
-      # We need it to make version 2 and 7 coexist.
-      # Be careful, binaries will not have the same name !
-      - name: Temporary rename binaries with 7
-        run: |
-          for exec in bragi bano2mimir cosmogony2mimir ctlmimir openaddresses2mimir osm2mimir poi2mimir ntfs2mimir query; do
-            sed -i -e "s/^name\s*=\s*\"$exec\"/name = \"${exec}7\"/" Cargo.toml;
-          done
-
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -42,6 +42,16 @@ else
 fi
 cargo install --locked $option --path=${MIMIRSBRUNN_DIR} --root=$rootdir
 
+# Rename all binaries with a suffix
+# Useful for tagging binaries that works on ES7 (for example, `bragi7` instead of `bragi`)
+for bin in $( ls ${rootdir}/bin/* )
+do
+  if [ -n "${2:-}" ]
+  then
+    mv "${bin}" "${bin}${2:-}"
+  fi
+done
+
 mkdir -p "$pkgdir/DEBIAN"
 
 cat << EOF > "$pkgdir/DEBIAN/control"


### PR DESCRIPTION
The CI workflow was broken when some parts have been removed from the `Cargo.toml` in 31d1defced203c34099a12a43d14f592f7c918fc.