### PR TITLE
fix: make 'bragi' backward compatible with 'mimir'

### DIFF
--- a/libs/places/src/poi.rs
+++ b/libs/places/src/poi.rs
@@ -41,6 +41,7 @@ pub struct Poi {
     pub context: Option<Context>,
     #[serde(default)]
     pub children: Vec<Poi>,
+    #[serde(default = "crate::utils::default_true")]
     pub autocomplete_visible: bool,
 }
 

--- a/libs/places/src/stop.rs
+++ b/libs/places/src/stop.rs
@@ -142,6 +142,7 @@ pub struct Stop {
     pub country_codes: Vec<String>,
 
     pub context: Option<Context>,
+    #[serde(default = "crate::utils::default_true")]
     pub autocomplete_visible: bool,
 }
 

--- a/libs/places/src/utils.rs
+++ b/libs/places/src/utils.rs
@@ -87,3 +87,7 @@ pub fn normalize_id(prefix: &str, id: &str) -> String {
         format!("{prefix}:{}", &id.replace(' ', ""))
     }
 }
+
+pub fn default_true() -> bool {
+    true
+}


### PR DESCRIPTION
When feeding ElasticSearch with an old version of `mimir` (before #828), the `autocomplete_visible` field will not be present in ElasticSearch. However, if we deploy a recent `bragi` version, it will try to deserialize `Poi` and/or `Stop` but will fail with 

```json
{
    "short": "query error",
    "long": "missing field `autocomplete_visible`"
}
```

Having a default value on deserialization should fix that and make it backward compatible.