### PR TITLE
Add children in api autocomplete

### DIFF
--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -107,7 +107,7 @@ where
         build_es_indices_to_search(&params.types, &params.pt_dataset, &params.poi_dataset);
     let lang = params.lang.clone();
     let filters = filters::Filters::from((params, geometry));
-    let excludes = ["boundary".to_string(), "children".to_string()];
+    let excludes = ["boundary".to_string()];
 
     for query_type in [QueryType::PREFIX, QueryType::FUZZY] {
         let dsl_query = dsl::build_query(


### PR DESCRIPTION
- As in api features, autocomplete should also contain children.
- Navitia is already modified not to display any Admins of children
- For mote details: https://navitia.atlassian.net/browse/NAV-2000
 